### PR TITLE
Release 0.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,5 +71,4 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc
           yarn
-          yarn build
-          npm publish ./dist
+          npm publish

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "type-check": "tsc",
     "test": "jest",
     "test:ci": "yarn lint && yarn type-check && yarn test",
-    "build": "tsc -p tsconfig.dist.json --declaration",
+    "build": "tsc -p tsconfig.dist.json --declaration && cp package.json dist/package.json",
     "prepush": "yarn lint && yarn type-check && jest --changedSince master",
     "prepack": "yarn build"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-artifactory",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "A graph conversion tool for https://jfrog.com/artifactory",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-artifactory",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "A graph conversion tool for https://jfrog.com/artifactory",
   "license": "MPL-2.0",
   "main": "dist/index.js",


### PR DESCRIPTION
This template was create before the `Fix publish action` PR made it into the `integration-template` project: 
https://github.com/JupiterOne/integration-template/pull/9

This caused the previous publish (#6) to [fail](https://github.com/JupiterOne/graph-artifactory/runs/1098465744?check_suite_focus=true) with 

```
yarn install v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.1.3: The platform "linux" is incompatible with this module.
info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
Done in 29.73s.
yarn run v1.22.5
$ tsc -p tsconfig.dist.json --declaration
Done in 5.10s.
npm ERR! code ENOENT
npm ERR! syscall open
npm ERR! path dist/package.json
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, open 'dist/package.json'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2020-09-10T19_58_39_641Z-debug.log
##[error]Process completed with exit code 254.
```
