### PR TITLE
Release 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-artifactory",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A graph conversion tool for https://jfrog.com/artifactory",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "type-check": "tsc",
     "test": "jest",
     "test:ci": "yarn lint && yarn type-check && yarn test",
-    "build": "tsc -p tsconfig.dist.json --declaration && cp package.json dist/package.json",
+    "build": "tsc -p tsconfig.dist.json --declaration",
     "prepush": "yarn lint && yarn type-check && jest --changedSince master",
     "prepack": "yarn build"
   },


### PR DESCRIPTION
Before recognizing that the npm publish issue had been fixed in https://github.com/JupiterOne/integration-template/pull/9, when looking into ways to solve the issue I had copied `package.json` into the `dist/` directory. I hadn't removed this before publishing 0.1.0.

It looks like the NPM resolver traversed all `package.json` files in the directory in order to determine which packages to include. Now that there was a `dist/package.json` with a field `"files: ["dist"]` (which actually points to `dist/dist/*`), all of the files in `dist/*` were excluded from the publish.

With `dist/package.json` **AND** `"files:["dist"]`:

```bash
> npm publish --dry-run

> @jupiterone/graph-artifactory@0.1.1 prepack .
> yarn build

yarn run v1.22.5
$ tsc -p tsconfig.dist.json --declaration
✨  Done in 1.07s.
npm notice 
npm notice 📦  @jupiterone/graph-artifactory@0.1.1
npm notice === Tarball Contents === 
npm notice 16.7kB LICENSE          
npm notice 1.2kB  dist/package.json
npm notice 1.2kB  package.json     
npm notice 403B   CHANGELOG.md     
npm notice 2.5kB  README.md        
npm notice === Tarball Details === 
npm notice name:          @jupiterone/graph-artifactory           
npm notice version:       0.1.1                                   
npm notice package size:  7.3 kB                                  
npm notice unpacked size: 22.1 kB                                 
npm notice shasum:        511f271321c50e3e0a5277228e44970b9535f9cc
npm notice integrity:     sha512-ToFOgVXJ4rX5n[...]s93LuT53W8zjQ==
npm notice total files:   5                                       
npm notice 
+ @jupiterone/graph-artifactory@0.1.1
```

With either (`dist/package.json` and (`"files": null` OR < no files property > )) OR ( <no `dist/package.json` file> ):

```bash
nickdowmon@Nicks-MacBook-Pro graph-artifactory % npm publish --dry-run

> @jupiterone/graph-artifactory@0.1.1 prepack .
> yarn build

yarn run v1.22.5
$ tsc -p tsconfig.dist.json --declaration
✨  Done in 1.08s.
npm notice 
npm notice 📦  @jupiterone/graph-artifactory@0.1.1
npm notice === Tarball Contents === 
npm notice 16.7kB  LICENSE                        
npm notice 7.2kB   dist/steps/access.js           
npm notice 2.0kB   dist/steps/account.js          
npm notice 2.1kB   dist/steps/builds.js           
npm notice 9.1kB   dist/client.js                 
npm notice 5.7kB   dist/constants.js              
npm notice 641B    dist/index.js                  
npm notice 672B    dist/steps/index.js            
npm notice 12.2kB  dist/steps/index.test.js       
npm notice 419B    dist/instanceConfigFields.js   
npm notice 8.0kB   dist/steps/permissions.js      
npm notice 2.0kB   dist/steps/pipelineSources.js  
npm notice 6.1kB   dist/steps/repositories.js     
npm notice 369B    dist/types.js                  
npm notice 751B    dist/validateInvocation.js     
npm notice 1.6kB   dist/validateInvocation.test.js
npm notice 1.2kB   dist/package.json              
npm notice 1.2kB   package.json                   
npm notice 403B    CHANGELOG.md                   
npm notice 2.5kB   README.md                      
npm notice 791B    dist/steps/access.d.ts         
npm notice 452B    dist/steps/account.d.ts        
npm notice 406B    dist/steps/builds.d.ts         
npm notice 3.2kB   dist/client.d.ts               
npm notice 1.0kB   dist/constants.d.ts            
npm notice 212B    dist/index.d.ts                
npm notice 226B    dist/steps/index.d.ts          
npm notice 194B    dist/instanceConfigFields.d.ts 
npm notice 466B    dist/steps/permissions.d.ts    
npm notice 432B    dist/steps/pipelineSources.d.ts
npm notice 818B    dist/steps/repositories.d.ts   
npm notice 4.6kB   dist/types.d.ts                
npm notice 241B    dist/validateInvocation.d.ts   
npm notice 231.6kB dist/tsconfig.dist.tsbuildinfo 
npm notice 274.9kB dist/tsconfig.tsbuildinfo      
npm notice === Tarball Details === 
npm notice name:          @jupiterone/graph-artifactory           
npm notice version:       0.1.1                                   
npm notice package size:  60.4 kB                                 
npm notice unpacked size: 600.4 kB                                
npm notice shasum:        88c42f9c9a0d7545d03623f08e05469c5f285c61
npm notice integrity:     sha512-s6TByGthzhiUj[...]N+l8ONNr1O6Cw==
npm notice total files:   35                                      
npm notice 
+ @jupiterone/graph-artifactory@0.1.1
```