### PR TITLE
Optional access token as it's not always required

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,7 @@ export const instanceConfigFields: IntegrationInstanceConfigFieldMap = {
   clientPipelineAccessToken: {
     type: 'string',
     mask: true,
+    optional: true
   },
   clientAdminName: {
     type: 'string',


### PR DESCRIPTION
![image](https://github.com/JupiterOne/graph-artifactory/assets/2235621/37f3af55-f4bb-4e61-b228-74f9332dacca)
You can uncheck that you want to use the client pipeline but we still were requiring the token