### PR TITLE
retry artifacts request with half limit when timeout error

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -283,6 +283,8 @@ export class APIClient extends BaseAPIClient {
   ): Promise<void> {
     let offset = 0;
     let currentLimit = initialLimit;
+    // 2 ** 3 means we'll try to reduce the page size 3 times before giving up.
+    // E.g. 1000 / 2 = 500 / 2 = 250 / 2 = 125
     const minLimit = Math.max(initialLimit / 2 ** 3, 1);
     const url = 'artifactory/api/search/aql';
     const getQuery = (repoKeys: string[], offset: number) => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -290,7 +290,6 @@ export class APIClient extends BaseAPIClient {
       const reposQuery = JSON.stringify(
         repoKeys.map((repoKey) => ({ repo: repoKey })),
       );
-      console.log('currentLimit :>> ', currentLimit);
       return `items.find({"$or": ${reposQuery}}).offset(${offset}).limit(${currentLimit})`;
     };
     let continuePaginating = false;

--- a/src/client.ts
+++ b/src/client.ts
@@ -8,7 +8,6 @@ import {
   ArtifactEntity,
   ArtifactoryAccessToken,
   ArtifactoryAccessTokenResponse,
-  ArtifactoryArtifactRef,
   ArtifactoryArtifactResponse,
   ArtifactoryBuild,
   ArtifactoryBuildArtifactsResponse,


### PR DESCRIPTION
We are getting timeout errors when requesting for artifacts, with this change I'm doing retries lowering the page size so hopefully the artifactory server responds in time.
We are also getting 500 errors on the `buildArtifact` request, but I'm not sure what's the issue so I'm enabling the option to log the error body and see if there's more context there